### PR TITLE
Bug - fix goal section's add_window radio button

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,3 +3,4 @@
 from models.storage.db import DBStorage
 
 db = DBStorage()
+db.reload()


### PR DESCRIPTION
When using the add window to add either a new goal or subgoal, the radio buttons are used to indicate your selection choice. 

Problem 1 was that toggling between the radio buttons caused some widgets to overlap.
Problem 2 was that new widgets were being creating after each toggle without destroying the previous widgets and thus wasting unnecessary memory.
Problem 3 occured when the add window is closed, reopened and the 'remove_frame' is for add_frame. I came to the conclusion that add frame's parent (add_window) was exited, destroyed and thus raised the error that its parent could not be found.

To fix the memory and widget overlap issue, the 'remove_frame' method was used and the creation of the add_frame and widgets is redone for every radio button toggle. 
To fix problem 3, the current_add_frame in use is set to None after every exit of add_window.